### PR TITLE
http3: remove link to HTTP trailer issue

### DIFF
--- a/content/docs/http3/client.md
+++ b/content/docs/http3/client.md
@@ -79,7 +79,6 @@ The code snippet shows all the knobs that need to be turned to send a request in
 * qlog Support: [#4124](https://github.com/quic-go/quic-go/issues/4124)
 * Happy Eyeballs Support: [#3755](https://github.com/quic-go/quic-go/issues/3755)
 * Support for Extensible Priorities ([RFC 9218](https://www.rfc-editor.org/rfc/rfc9218.html)): [#3470](https://github.com/quic-go/quic-go/issues/3470)
-* Support for HTTP Trailers: [#2266](https://github.com/quic-go/quic-go/issues/2266)
 * Use [`Early-Data` header field](https://datatracker.ietf.org/doc/html/rfc8470#section-5.1) for 0-RTT requests, retry on 425 response status: [#4381](https://github.com/quic-go/quic-go/issues/4381)
 * Use `url.Error`s for all `http3.RoundTripper` errors: [#4204](https://github.com/quic-go/quic-go/issues/4202)
 * Support for 1xx Status Codes (including Early Hints, 103): [#4403](https://github.com/quic-go/quic-go/issues/4403)

--- a/content/docs/http3/server.md
+++ b/content/docs/http3/server.md
@@ -119,4 +119,3 @@ func(w http.ResponseWriter, r *http.Request) {
 * Correctly deal with 0-RTT and HTTP/3 extensions: [#3855](https://github.com/quic-go/quic-go/issues/3855)
 * Support for Extensible Priorities ([RFC 9218](https://www.rfc-editor.org/rfc/rfc9218.html)): [#3470](https://github.com/quic-go/quic-go/issues/3470)
 * Support for httptrace: [#3342](https://github.com/quic-go/quic-go/issues/3342)
-* Support for HTTP Trailers: [#2266](https://github.com/quic-go/quic-go/issues/2266)


### PR DESCRIPTION
Once https://github.com/quic-go/quic-go/pull/4581 and https://github.com/quic-go/quic-go/pull/4630 are merged.