### PR TITLE
http3: remove link to resolved url.Error issue

### DIFF
--- a/content/docs/http3/client.md
+++ b/content/docs/http3/client.md
@@ -80,4 +80,3 @@ The code snippet shows all the knobs that need to be turned to send a request in
 * Happy Eyeballs Support: [#3755](https://github.com/quic-go/quic-go/issues/3755)
 * Support for Extensible Priorities ([RFC 9218](https://www.rfc-editor.org/rfc/rfc9218.html)): [#3470](https://github.com/quic-go/quic-go/issues/3470)
 * Use [`Early-Data` header field](https://datatracker.ietf.org/doc/html/rfc8470#section-5.1) for 0-RTT requests, retry on 425 response status: [#4381](https://github.com/quic-go/quic-go/issues/4381)
-* Use `url.Error`s for all `http3.RoundTripper` errors: [#4204](https://github.com/quic-go/quic-go/issues/4202)


### PR DESCRIPTION
The conclusion was that this issue doesn't need to be resolved, hence it was closed. See https://github.com/quic-go/quic-go/issues/4202#issuecomment-2209880727 for details.