### PR TITLE
ci: exclude qvis from link checker

### DIFF
--- a/.github/workflows/linkcheck-skipfile.txt
+++ b/.github/workflows/linkcheck-skipfile.txt
@@ -2,3 +2,6 @@ https://github.com/quic-go/docs
 https://analytics.seemann.io
 https://quic-go.net
 http://localhost:5001/prometheus
+
+# qvis is down every now and then
+https://qvis.quictools.info/


### PR DESCRIPTION
qvis is down every now and then. This shouldn't break our build.