### PR TITLE
http3: remove QPACK Error Codes from future work section

### DIFF
--- a/content/docs/http3/qpack.md
+++ b/content/docs/http3/qpack.md
@@ -15,4 +15,3 @@ If you think that your application would benefit from higher compression efficie
 ## 📝 Future Work
 
 * Add support for the QPACK dynamic table: [#2424](https://github.com/quic-go/quic-go/issues/2424) and [qpack#33](https://github.com/quic-go/qpack/issues/33)
-* QPACK Error Codes: [#4406](https://github.com/quic-go/quic-go/issues/4406)


### PR DESCRIPTION
This was implemented in https://github.com/quic-go/quic-go/pull/5439.