### PR TITLE
webtransport: expand WebTransport HTTP3 server example

### DIFF
--- a/content/docs/webtransport/server.md
+++ b/content/docs/webtransport/server.md
@@ -28,6 +28,8 @@ s := webtransport.Server{
     },
 }
 
+webtransport.ConfigureHTTP3Server(s.H3)
+
 // Create a new HTTP endpoint /webtransport.
 http.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
     sess, err := s.Upgrade(w, r)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `webtransport.ConfigureHTTP3Server` call to WebTransport HTTP/3 server example
Adds the missing `webtransport.ConfigureHTTP3Server(s.H3)` call in the Go code snippet in [server.md](https://github.com/quic-go/docs/pull/126/files#diff-b27f9ebec734bd269e21920fc46b44452f66c75d37d91f29b95e2696dd267609). Without this call, the example is incomplete and the server would not be correctly configured for WebTransport.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a3fd4e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->