### PR TITLE
use errors.AsType for error assertions

### DIFF
--- a/content/docs/connect-udp/proxy.md
+++ b/content/docs/connect-udp/proxy.md
@@ -35,8 +35,7 @@ http.Handle("/masque", func(w http.ResponseWriter, r *http.Request) {
   // parse the UDP proxying request
   mreq, err := masque.ParseRequest(r, t)
   if err != nil {
-    var perr *masque.RequestParseError
-    if errors.As(err, &perr) {
+    if perr, ok := errors.AsType[*masque.RequestParseError](err); ok {
       w.WriteHeader(perr.HTTPStatus)
       return
     }

--- a/content/docs/quic/connection.md
+++ b/content/docs/quic/connection.md
@@ -136,7 +136,7 @@ if _, ok := errors.AsType[*quic.StatelessResetError](err); ok {
 } else if vnErr, ok := errors.AsType[*quic.VersionNegotiationError](err); ok {
   // version negotiation error
   ourVersions := vnErr.Ours     // locally supported QUIC versions
-  theirVersions := vnErr.Theirs // QUIC versions support by the remote
+  theirVersions := vnErr.Theirs // QUIC versions supported by the remote
 }
 ```
 

--- a/content/docs/quic/connection.md
+++ b/content/docs/quic/connection.md
@@ -134,7 +134,7 @@ if _, ok := errors.AsType[*quic.StatelessResetError](err); ok {
   errorCode := transportErr.ErrorCode       // error code (RFC 9000, section 20.1)
   errorMessage := transportErr.ErrorMessage // error message
 } else if vnErr, ok := errors.AsType[*quic.VersionNegotiationError](err); ok {
-  // version negotation error
+  // version negotiation error
   ourVersions := vnErr.Ours     // locally supported QUIC versions
   theirVersions := vnErr.Theirs // QUIC versions support by the remote
 }

--- a/content/docs/quic/connection.md
+++ b/content/docs/quic/connection.md
@@ -117,32 +117,23 @@ The most common way to handle an error is by interface-asserting it to `net.Erro
 The following example shows how to inspect an error in detail:
 
 ```go
-var (
-  statelessResetErr   *quic.StatelessResetError
-  handshakeTimeoutErr *quic.HandshakeTimeoutError
-  idleTimeoutErr      *quic.IdleTimeoutError
-  appErr              *quic.ApplicationError
-  transportErr        *quic.TransportError
-  vnErr               *quic.VersionNegotiationError
-)
-switch {
-case errors.As(err, &statelessResetErr):
+if _, ok := errors.AsType[*quic.StatelessResetError](err); ok {
   // stateless reset
-case errors.As(err, &handshakeTimeoutErr):
+} else if _, ok := errors.AsType[*quic.HandshakeTimeoutError](err); ok {
   // connection timed out before completion of the handshake
-case errors.As(err, &idleTimeoutErr):
+} else if _, ok := errors.AsType[*quic.IdleTimeoutError](err); ok {
   // idle timeout
-case errors.As(err, &appErr):
+} else if appErr, ok := errors.AsType[*quic.ApplicationError](err); ok {
   // application error
   remote := appErr.Remote             // was the error triggered by the peer?
   errorCode := appErr.ErrorCode       // application-defined error code
   errorMessage := appErr.ErrorMessage // application-defined error message
-case errors.As(err, &transportErr):
+} else if transportErr, ok := errors.AsType[*quic.TransportError](err); ok {
   // transport error
   remote := transportErr.Remote             // was the error triggered by the peer?
   errorCode := transportErr.ErrorCode       // error code (RFC 9000, section 20.1)
   errorMessage := transportErr.ErrorMessage // error message
-case errors.As(err, &vnErr):
+} else if vnErr, ok := errors.AsType[*quic.VersionNegotiationError](err); ok {
   // version negotation error
   ourVersions := vnErr.Ours     // locally supported QUIC versions
   theirVersions := vnErr.Theirs // QUIC versions support by the remote

--- a/content/docs/quic/streams.md
+++ b/content/docs/quic/streams.md
@@ -115,8 +115,7 @@ When a stream is reset (i.e. when `CancelRead` or `CancelWrite` are used), appli
 QUIC itself does not interpret this value; instead, it is the responsibility of the application layer to assign specific meanings to different error codes. 
 
 ```go
-var streamErr *quic.StreamError
-if errors.As(err, &streamErr) {
+if streamErr, ok := errors.AsType[*quic.StreamError](err); ok {
   errorCode := streamErr.ErrorCode
 }
 ```

--- a/content/docs/webtransport/session.md
+++ b/content/docs/webtransport/session.md
@@ -23,8 +23,7 @@ Similar to closing a `quic.Conn`, this action causes all calls to `AcceptStream`
 
 On the receiver side, this error will be surfaced as a `webtransport.SessionError`:
 ```go
-var sessErr *webtransport.SessionError
-if errors.As(err, &sessErr) {
+if sessErr, ok := errors.AsType[*webtransport.SessionError](err); ok {
   errorCode := sessErr.ErrorCode
   errorMessage := sessErr.Message
 }

--- a/content/docs/webtransport/streams.md
+++ b/content/docs/webtransport/streams.md
@@ -18,8 +18,7 @@ WebTransport itself does not interpret this value; instead, it is the responsibi
 Below is an example of how to type-assert an error as a `webtransport.StreamError`:
 
 ```go
-var streamErr *webtransport.StreamError
-if errors.As(err, &streamErr) {
+if streamErr, ok := errors.AsType[*webtransport.StreamError](err); ok {
   errorCode := streamErr.ErrorCode
 }
 ```


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace `errors.As` with `errors.AsType` in documentation error handling examples
Updates code examples across the docs to use the generic `errors.AsType` helper, which inlines variable declaration and type assertion into a single `if` statement. This removes the pattern of pre-declaring a typed variable and passing its address to `errors.As`. Affected files: [proxy.md](https://github.com/quic-go/docs/pull/128/files#diff-60e7e2db097442cd94473c69d2ff674b9a1301bae8293c993bbc6d00b4bc1378), [connection.md](https://github.com/quic-go/docs/pull/128/files#diff-46aa1900e941e39d9a941157706a67e5d300cbbc751cf18b04069414e038fd03), [streams.md](https://github.com/quic-go/docs/pull/128/files#diff-ae6ac7e5f4feb103b643e1d6c2b6f1b6213cbcd32f9a6474823c7469889acbaa), [session.md](https://github.com/quic-go/docs/pull/128/files#diff-a3e5228d9b5f3c5ec7365474148ab9d2a0c0bea6e9b818a92b15d2d94a8fd29f), and [streams.md](https://github.com/quic-go/docs/pull/128/files#diff-2b60bd2085bb8768115c40aff67f4613fb2d2fdde62b44d4ba3218a8887b7ccb). Also fixes two comment typos in the QUIC connection example.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5677f4.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->