### PR TITLE
webtransport: document application protocol negotiation

### DIFF
--- a/content/docs/webtransport/client.md
+++ b/content/docs/webtransport/client.md
@@ -21,8 +21,27 @@ The server might reject this request, in which case the status code of the HTTP 
 
 The parameters for the underlying QUIC connection can be adjusted by setting the `QUICConfig` on the `Dialer`. [Datagram support]({{< relref "../quic/datagrams.md" >}}) is required by WebTransport, and must be enabled on using `quic.Config.EnableDatagrams`.
 
+## Application Protocol Negotiation
+
+A client can advertise WebTransport application protocols by setting `ApplicationProtocols` on the `Dialer`. This is the WebTransport-specific negotiation described in the [Application Protocol Negotiation section](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3#section-3.3) of the WebTransport over HTTP/3 draft, not TLS ALPN.
+
+```go
+d := webtransport.Dialer{
+    ApplicationProtocols: []string{"foo", "bar"},
+}
+
+_, sess, err := d.Dial(ctx, "https://example.com/webtransport", nil)
+// ... error handling
+
+selected := sess.SessionState().ApplicationProtocol
+if selected == "" {
+    // The server accepted the session without selecting an application protocol.
+}
+```
+
+If the server selects one of the offered protocols, it is available through `sess.SessionState().ApplicationProtocol`. If the server accepts the session without selecting a protocol, `ApplicationProtocol` is empty.
+
 ## 📝 Future Work
 
 * Using the same QUIC connection for WebTransport and HTTP/3: [#147](https://github.com/quic-go/webtransport-go/issues/147)
 * Allow Optimistic Opening of Streams: [#136](https://github.com/quic-go/webtransport-go/issues/136)
-* Subprotocol Negotiation: [#132](https://github.com/quic-go/webtransport-go/issues/132)

--- a/content/docs/webtransport/server.md
+++ b/content/docs/webtransport/server.md
@@ -42,6 +42,44 @@ http.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
 s.ListenAndServeTLS(<certFile>, <keyFile>)
 ```
 
+## Application Protocol Negotiation
+
+A server can select a WebTransport application protocol offered by the client by setting `ApplicationProtocols`. This is the WebTransport-specific negotiation described in the [Application Protocol Negotiation section](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3#section-3.3) of the WebTransport over HTTP/3 draft, not TLS ALPN.
+
+```go
+s := webtransport.Server{
+    H3: &http3.Server{
+        Addr:      ":443",
+        TLSConfig: &tls.Config{}, // use your tls.Config here
+    },
+    ApplicationProtocols: []string{"foo", "bar"},
+}
+```
+
+`Upgrade` selects the first client-offered protocol that also appears in `ApplicationProtocols`. The selected protocol is available on the returned session:
+
+```go
+http.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
+    sess, err := s.Upgrade(w, r)
+    if err != nil {
+        log.Printf("upgrading failed: %s", err)
+        w.WriteHeader(500)
+        return
+    }
+
+    switch sess.SessionState().ApplicationProtocol {
+    case "foo":
+        // handle foo
+    case "bar":
+        // handle bar
+    default:
+        // No application protocol was negotiated.
+    }
+})
+```
+
+If there is no overlap between the client's offered protocols and the server's `ApplicationProtocols`, `Upgrade` accepts the session without selecting a protocol and `ApplicationProtocol` is empty.
+
 ## Origin Validation
 
 By default, the `Upgrade` function checks that the client's request origin matches the host of the server. This prevents cross-site request forgery (CSRF) attacks, where an attacker could use a malicious web page to establish a WebTransport connection to a vulnerable application, with the application processing the connection as if it were part of the victim user's session.
@@ -60,5 +98,4 @@ s := webtransport.Server{
 
 ## 📝 Future Work
 
-* Subprotocol Negotiation: [#132](https://github.com/quic-go/webtransport-go/issues/132)
 * Properly check Validity of the client's SETTINGS: [#106](https://github.com/quic-go/webtransport-go/issues/106)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Document WebTransport application protocol negotiation for clients and servers
Adds an 'Application Protocol Negotiation' section to both the [client](https://github.com/quic-go/docs/pull/129/files#diff-35c88c2d17dc93510c0cb79b2f6eeb137f36107e651d2d51fe00894a285e3ea8) and [server](https://github.com/quic-go/docs/pull/129/files#diff-b27f9ebec734bd269e21920fc46b44452f66c75d37d91f29b95e2696dd267609) WebTransport docs. The client docs explain how to set `Dialer.ApplicationProtocols` and retrieve the selected protocol via `sess.SessionState().ApplicationProtocol`. The server docs cover configuring `Server.ApplicationProtocols`, routing based on the selected protocol, and the behavior when there is no overlap (session is accepted but `ApplicationProtocol` is empty). Also removes the 'Subprotocol Negotiation' bullet from the 'Future Work' section in both docs.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e310523.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->