### PR TITLE
ci: pin non-GitHub-owned GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: '0.152.2'
           extended: true
@@ -24,7 +24,7 @@ jobs:
         run: hugo --minify -d build
       - name: Push build results to separate branch # purely for debuggability
         if: ${{ github.event_name == 'push' }}
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Pin third-party GitHub Actions to specific commit SHAs in deploy workflow
Replaces floating major version tags (`v3`, `v4`) for `peaceiris/actions-hugo` and `peaceiris/actions-gh-pages` with pinned commit SHAs in [deploy.yml](.github/workflows/deploy.yml). The pinned versions correspond to v3.2.1 and v4.1.0 respectively, noted in inline comments.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e79e398.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->